### PR TITLE
Second revision of OBF Bylaws, part 1

### DIFF
--- a/OBF Bylaws.md
+++ b/OBF Bylaws.md
@@ -80,7 +80,7 @@ ARTICLE IV - NOMINATIONS AND ELECTIONS
 
 1.	Nominations
     a. Nominations for the Board of Directors may be made by the general membership at any time throughout the year by email to any Board Member.
-    b. The names of Board Member candidates shall be presented to the general membership prior to holding the election, with at least the same advance notificiation period as pertains to public Board meetings (see Article II, Item 4).
+    b. The names of Board Member candidates shall be presented to the general membership prior to holding the election, with at least the same advance notification period as pertains to public Board meetings (see Article II, Item 4).
 2.	Elections of officers and Directors shall be held at a public Board of Directors meeting. Elections to the three Officer positions by the membership may also be held during a time of no more than the four weeks leading up to a public Board of Directors meeting. Nominations made at least 60 (sixty) days prior to a public meeting are eligible for inclusion on the election ballot at that meeting. This requirement may be waived by the majority of the Board of Directors.
 3.	Voting.
     a.	Voting for the Board of Directors shall be by electronic or paper ballot. The President or Secretary shall prepare the ballot of candidates to be used for the purpose of voting.

--- a/OBF Bylaws.md
+++ b/OBF Bylaws.md
@@ -24,7 +24,7 @@ ARTICLE II - MEETINGS
 ------------------
 
 1.	OBF Board Of Directors meetings shall be open to the public and shall be held at any physical venue, or through an online medium or a conference call, that can be joined by the public.
-2.	The Board of Directors will be elected at the annual meeting of the OBF.
+2.	Board of Director candidates will be elected at a public meeting of the Board of Directors.
 3.	Special meetings of the Board Of Directors may be called at any time by a majority of the Board of Directors upon 10 (ten) days notification. Special meetings will typically not be held in a physical location.
 4.	Meeting Notification
     a.	Notice of Board Of Director meetings shall be emailed to each member at least 10 (ten) days, but not more than 60 (sixty) days prior to such meetings. Members must provide an electronic email address to be notified. Alternatively, the Board may require members to subscribe to an email list to which this and other Board announcements will be posted.
@@ -41,7 +41,7 @@ ARTICLE II - MEETINGS
 ARTICLE III - BOARD OF DIRECTORS
 ----------------------------
 
-1.	The Board of Directors shall consist of President, Secretary, Treasurer, Parliamentarian, and additional Board Members at Large. The number of Board Members at Large is decided by majority vote of the current Board of Directors and may be proposed by either the general membership or a Board Member.
+1.	The Board of Directors shall consist of President, Secretary, Treasurer, and additional Board Members at Large. The number of Board Members at Large is decided by majority vote of the current Board of Directors and may be proposed by either the general membership or a Board Member.
 2.	Term of Office.
     a.	The term of office for Directors shall begin after the conclusion of the Board meeting at which they are elected.
     b.	Directors shall serve for a term of 2 (two) years and shall hold office until their successors' terms begin. 
@@ -49,12 +49,12 @@ ARTICLE III - BOARD OF DIRECTORS
 3.	A majority of Directors shall, at its option, declare the seat of a Director to be vacant if that Director is absent for 2 (two) consecutive Board meetings (as defined in Article II), or fails to remain a member in good standing for a period of more than 4 (four) weeks.
 4.	Any Director shall be removed by a 2/3 (two thirds) majority vote of the Board of Directors. 
 5.	All resignations from the Board shall be presented in writing, whether in electronic or paper form, to the Board of Directors.
-6.	When a vacancy occurs, the Nomination Committee shall appoint a successor to fill the remainder of the term of office. The successor shall be confirmed by the Board of Directors by majority vote.
+6.	_Removed_.
 7.	The duties for each Board Officer shall be, but are not limited to:
     a.	President
         (1)	Serve as Chief Executive Officer of the OBF
         (2)	Preside at all Board and General Membership meetings
-        (3)	Serve in the role of Project Liaison, with the rights and obligations conveyed by this role, to Software in the Public Interest, Inc. (SPI), while OBF is an associated project of SPI.
+        (3)	Interpret and rule on procedural matters at all meetings.
         (4)	Appoint special committees and committee members as necessary
         (5)	Assume responsibility for the preparation of agendas for General Membership meeting
     b.	Secretary
@@ -67,13 +67,10 @@ ARTICLE III - BOARD OF DIRECTORS
         (2)	Account for all monies received by the OBF and its committees
         (3)	Provide an annual balance sheet for the OBF and keep the Board informed as to the fiscal status of OBF.
         (4)	Prepare an annual budget
-    d.	Parliamentarian
-        (1)	Interpret and rule on procedural matters at all meetings.
-        (2)	Chair the Nominating committee.
-        (3)	Chair the Bylaws Review committee.
-    e.	Board Member(s) at Large
+        (5)	Serve in the role of Project Liaison, with the rights and obligations conveyed by this role, to Software in the Public Interest, Inc. (SPI), while OBF is an associated project of SPI.
+    d.	Board Member(s) at Large
         (1)	Assist the other Board Members as needed.
-8.	The Board of Directors shall hold at least 1 (one) meeting per year, at a time and place set by Board members. Additional meetings shall be called at the discretion of the President or at the written request of a majority of Board members. Meetings must meet the requirements set forth in Article II (see Items 1 and 4).
+8.	The Board of Directors shall hold at least 1 (one) meeting per year, at a time and place set by Board members. Additional meetings shall be called at the discretion of the President or at the written request of a majority of Board members. Such meetings must meet the requirements set forth in Article II (see Items 1 and 4).
 9.	The Board of Directors may, upon a vote of the majority of the attending Directors, and provided the quorum is met, adjourn a Board meeting and reconvene in an Executive Session to discuss and vote upon personnel matters, litigation in which OBF is or may be involved, and other matters of business of a similar nature. Only members of the Board of Directors shall be entitled to attend Executive Sessions. The nature of any and all business to be considered in the Executive Session shall first be announced in open, public, session.
 10.	Each member of the Board shall have one vote at Board meetings. For approval ballots, each Board member shall have as many votes as candidates on the ballot, but cast at most one vote per candidate.
 11.	The Board of Directors shall receive no compensation for any service which may be rendered to the OBF. Since directors receive no compensation, they shall under no circumstances be personally or jointly financially liable for any decision made in good faith on behalf of the OBF.
@@ -81,12 +78,14 @@ ARTICLE III - BOARD OF DIRECTORS
 ARTICLE IV - NOMINATIONS AND ELECTIONS
 -----------------------------------
 
-1.	Nominations for the Board of Directors may be made by the general membership at any time throughout the year by email to any member of the Nominating Committee (see Item 7), or by the Nominating Committee itself. 
-2.	Elections of officers and Directors shall be held at the annual Board of Directors meeting. Elections to the four Officer positions by the membership may also be held during a time of no more than the four weeks leading up to the annual Board of Directors meeting. Nominations made at least 60 (sixty) days prior to this annual meeting are eligible for inclusion on the election ballot at that meeting. This requirement may be waived by the majority of the Board of Directors.
+1.	Nominations
+    a. Nominations for the Board of Directors may be made by the general membership at any time throughout the year by email to any Board Member.
+    b. The names of Board Member candidates shall be presented to the general membership prior to holding the election, with at least the same advance notificiation period as pertains to public Board meetings (see Article II, Item 4).
+2.	Elections of officers and Directors shall be held at a public Board of Directors meeting. Elections to the three Officer positions by the membership may also be held during a time of no more than the four weeks leading up to a public Board of Directors meeting. Nominations made at least 60 (sixty) days prior to a public meeting are eligible for inclusion on the election ballot at that meeting. This requirement may be waived by the majority of the Board of Directors.
 3.	Voting.
-    a.	Voting for the Board of Directors shall be by electronic or paper ballot.
+    a.	Voting for the Board of Directors shall be by electronic or paper ballot. The President or Secretary shall prepare the ballot of candidates to be used for the purpose of voting.
     b.	Voting shall be by Approval Vote. All nominees will be on the ballot, and each Director or member may cast as many votes as nominees, but at most one vote for each nominee. A nominee must receive a majority of votes (or 'Yes' votes) to win a seat. If there are more than one nominees for an office, or more nominees than seats to fill, the nominee or nominees with the highest number of votes (or 'Yes' votes) win the seats to be filled.
-    c.	Only the four Officers (see Article II, Items 2 and 8) may be elected by the general membership. The Board Members at Large shall be elected by the Board of Directors.
+    c.	Only the three Officers (see Article II, Items 2 and 8) may be elected by the general membership. The Board Members at Large shall be elected by the Board of Directors.
     d.	Ties in elections shall be broken by the President.
     e.	Ballots submitted to the general membership shall be secret. Board of Director votes for Directors shall be secret.
 4.	If a current Board Member at Large is nominated and elected officer, her previous Board seat becomes vacant and therefore available for election, unless the Board also decides to reduce the size of the Board.
@@ -95,16 +94,12 @@ ARTICLE IV - NOMINATIONS AND ELECTIONS
     a.	Nominees or appointees for Director positions (Board Members at Large) must be voting members of the OBF in good standing.
     b.	Nominees or appointees for Officer positions must have been voting members of the OBF for a minimum of one year, be in good standing, and have previously served on the Board of Directors for a minimum of one year.
     c.	The Board of Directors may waive qualification requirements at its discretion by unanimous consent of attending Directors, provided the quorum is met. If the membership requirement is waived for a nominee, the nominee automatically becomes a member upon election, and must meet all requirements to be in good standing within 4 (four) weeks after election. 
-7.	Nominating Committee
-    a.	The committee shall consist of the Parliamentarian and a minimum of 2 (two) active members of the OBF.
-    b.	The committee shall attempt to contact members of the Board of Directors and active members of the OBF in an effort to identify eligible members interested in serving on the Board of Directors, and to solicit nominations from the general membership.
-    c.	The committee shall present the names of candidates to the general membership prior to the annual Board meeting.
-    d.	The committee shall prepare an electronic or paper ballot of candidates to be used at the annual meeting for the purpose of voting.
+7.	_Removed_.
 8.	Paper ballots shall be counted by 2 (two) active members of the OBF selected by the President. Electronic ballots will be counted electronically.
 9.	Election results shall be recorded and filed in the minutes.
 
 ARTICLE V - BYLAW AMENDMENTS
 ---------------------------
 
-1. These bylaws shall be amended by a 2/3 (two-thirds) majority vote of the Board of Directors at any meeting of the Board, provided the quorum is met and that prior written or email notice has been given to the membership (as in Article II, Item 4).
-2. These bylaws shall be reviewed every 2 (two) years by the committee convened and chaired by the Parliamentarian and 2 (two) active members of the OBF nominated by the Parliamentarian.
+1. These bylaws shall be amended by a 2/3 (two-thirds) majority vote of the Board of Directors at any public meeting of the Board, provided the quorum is met and that prior written or email notice has been given to the membership (as in Article II, Item 4).
+2. These bylaws shall be reviewed every 2 (two) years by a special committee convened by the Board of Directors.


### PR DESCRIPTION
This set of proposed revisions to the OBF Bylaws makes the following changes:

* Remove the Parliamentarian officer, and reassigns (or removes, see
  below) their roles.
* Removes Nominating Committee, and simplifies nomination process.
* Simplifies process for Bylaws review by giving authority on how to
  conduct the review to the Board.

The revision maintains all first (Article) and second (Item) level numbering so as not to possibly change a reference (external or internal) to an Article or Item it was not originally meant to reference. Therefore, rather than renumbering subsequent items, deleted items are maintained but listed as _Removed_. This also helps to clarify the diff between versions.