### PR TITLE
Updates to the financial report template

### DIFF
--- a/Financial-Reports/report-template.md
+++ b/Financial-Reports/report-template.md
@@ -1,18 +1,22 @@
 # Financial Report for FY YYYY
 
-This is a report about OBF's financial assets and transactions during OBF's YYYY financial year. For financial year for OBF goes from December to November of the following year, and hence this report covers the period from December YYYY to November YYYY.
+This is a report about OBF's financial assets and transactions during OBF's YYYY financial year. The financial year for OBF goes from December to November of the following year, and hence this report covers the period from December YYYY to November YYYY.
 
 ## Summary
 
-| Item                   | Amount         |
-|------------------------|---------------:|
-| **Starting Balance**   | **$NN,NNN.NN** |
-| Income                 |   $NN,NNN.NN   |
-| Expenses               | _($NN,NNN.NN)_ |
-| SPI fees               | _($NN,NNN.NN)_ |
-| **Ending Balance**     | **$NN,NNN.NN** |
-| Encumbrances           | _($NN,NNN.NN)_ |
-|**Unencumbered Balance**| **$NN,NNN.NN** |
+| Item                        | Amount         |
+|-----------------------------|---------------:|
+| **Starting Balance**        | **$NN,NNN.NN** |
+| Income                      |   $NN,NNN.NN   |
+| Expenses                    | _($NN,NNN.NN)_ |
+| SPI fees                    | _($NN,NNN.NN)_ |
+| **Ending Balance**          | **$NN,NNN.NN** |
+| Encumbrances                | _($NN,NNN.NN)_ |
+|**Unencumbered Balance**     | **$NN,NNN.NN** |
+|-----------------------------|----------------|
+| BOSC Escrow Account         |   $NN,NNN.NN   |
+|**Total financial assets**   | **$NN,NNN.NN** |
+|**Total unencumbered assets**| **$NN,NNN.NN** |
 
 Encumbrances come from unpaid liabilities and similar commitments already incurred, but not yet paid.
 
@@ -22,47 +26,57 @@ As of April 1, 2013, OBF does not maintain its own bank accounts anymore. All of
 
 ## Income
 
-| Item   | Date(s)  | Amount  |
-|--------|----------|--------:|
+| Item                                        |Date(s)|   Amount  |
+|:--------------------------------------------|:-----:|----------:|
 |        |   |   |
 |        |   |   |
 |        |   |   |
 
-Total income (gross):
-Total income (net):
+Total income:
 
 ## Expenses
 
-| Item   | Date(s)  | Amount  |
-|--------|----------|--------:|
+| Item                                        |Date(s)|   Amount  |
+|:--------------------------------------------|:-----:|----------:|
 |        |   |   |
 |        |   |   |
 |        |   |   |
+|---------------------------------------------|-------|-----------|
+| SPI 5% fees                                 |       |   $NNN.NN |
 
-Total expenses (gross):
-Total expenses (net):
+Totals for FY YYYY:
++ Total programmatic expenses paid:            $N,NNN.NN
++ Total expenses:                              $N,NNN.NN
 
 ## Encumbrances
 
-Encumbrances are unpaid liabilities and other financial commitments already incurred, but not yet paid.
+Encumbrances are unpaid liabilities and other financial commitments already incurred, but not yet paid. This includes expenses paid by, but not yet reimbursed to Board members and other persons authorized to make payments on behalf of the OBF.
 
-| Item   | Date(s)  | Amount  |
-|--------|----------|--------:|
+| Item                           |     Date(s)       |   Amount  |
+|:-------------------------------|:-----------------:|----------:|
 |        |   |   |
 |        |   |   |
 |        |   |   |
 
-Total encumbrances (gross):
-Total encumbrances (net):
+Total encumbrances:
 
 ## BOSC YYYY
 
-| Item                 | Amount         |
-|----------------------|---------------:|
-| **Starting Balance** | **$NN,NNN.NN** |
-| BOSC Income          |   $NN,NNN.NN   |
-| BOSC Expenses        | _($NN,NNN.NN)_ |
-| Surplus share        |   $NN,NNN.NN   |
-| **Ending Balance**   | **$NN,NNN.NN** |
+| Item                    | Amount         |
+|:------------------------|---------------:|
+| **Starting Balance**    | **$NN,NNN.NN** |
+| BOSC Profit share       |   $ N,NNN.NN   |
+| Programmatic Activities | _($ N,NNN.NN)_ |
+| **Ending Balance**      | **$NN,NNN.NN** |
+|-------------------------|----------------|
+| BOSC Income             |   $NN,NNN.NN   |
+| BOSC Expenses           | _($NN,NNN.NN)_ |
+| **BOSC Surplus**        | **$NN,NNN.NN** |
+
+_Programmatic Activities_ are BOSC/OBF-sponsored activities that go beyond operational activities and logistics already managed and thus covered by ISMB, and includes travel awards, comp'ed registrations, and speaker support. For BOSC YYYY, these include the following:
+
+- NN comp'ed registrations:       $N,NNN.NN
+- Keynote speaker reimbursements: $N,NNN.NN
+- Student travel awards:          $  NNN.NN
 
 [SPI]: http://spi-inc.org


### PR DESCRIPTION
The updates carry over changes over time to the 2013 Financial Report, so that a Financial Report generated from the template would have almost the same structure, except for the section about the transition to SPI, which was specific to the 2013 report.