### PR TITLE
Financial report for OBF FY 2014

### DIFF
--- a/Financial-Reports/Financial report 2014.md
+++ b/Financial-Reports/Financial report 2014.md
@@ -1,0 +1,111 @@
+# Financial Report for FY 2014
+
+This is a report about OBF's financial assets and transactions during OBF's 2014 financial year. The financial year for OBF goes from December to November of the following year, and hence this report covers the period from December 2013 to November 2014.
+
+## Summary
+
+| Item                        | Amount         |
+|-----------------------------|---------------:|
+| **Starting Balance**        | **$39,376.08** |
+| Income                      |   $ 7,482.00   |
+| Expenses                    | _($ 2,289.16)_ |
+| SPI fees                    | _($    49.94)_ |
+| **Ending Balance**          | **$44,518.98** |
+| Encumbrances                | _($ 2,982.94)_ |
+|**Unencumbered Balance**     | **$41,536.04** |
+|-----------------------------|----------------|
+| BOSC Escrow Account         |   $12,617.25   |
+|**Total financial assets**   | **$57,136.23** |
+|**Total unencumbered assets**| **$54,153.29** |
+
+Encumbrances come from unpaid liabilities and similar commitments already incurred, but not yet paid.
+
+## OBF under financial sponsorship
+
+As of April 1, 2013, OBF does not maintain its own bank accounts anymore. All of OBF's financial assets have been transferred to, and are now managed by Software in the Public Interest ([SPI]), a fiscal sponsorship organization for open-source projects with which OBF became an associated project in October 2012.
+
+## Income
+
+| Item                                        |Date(s)|   Amount  |
+|:--------------------------------------------|:-----:|----------:|
+| Sponsorship of 2014 BOSC                    | 3/26  |    $  500 |
+| Sponsorship of 2014 BOSC (./. $18 wire fee) | 3/31  |    $  982 |
+| Sponsorship of 2014 BOSC                    | 5/28  |    $5,000 |
+| Sponsorship of 2014 BOSC                    | 9/27  |    $1,000 |
+
+Sponsorships were from Harbinger Partners, GigaScience, Google, and
+Curoverse. Another sponsorship commitment, from Eagle Genomics, was
+received in cash only in Jan 2015, and is hence not accounted for in
+FY 2014.
+
+The Google Summer of Code Mentoring Organization payment for OBF's
+2014 GSoC participation ($3,000 mentor stipends, plus 791.99 GSoC
+summit travel reimbursement) was only received in Feb 2015, and hence
+is not accounted for in FY 2014.
+
+Total income: $7,482
+
+## Expenses
+
+| Item                                        |Date(s)|   Amount  |
+|:--------------------------------------------|:-----:|----------:|
+| Amazon Hosting Dec 2012-Nov 2013            | 1/2   | $2,214.65 |
+| Biomoby.org renewal (incurred 9/29/2013)    | 1/2   |    $10.00 |
+| BioR.org renewal (incurred 11/3/2013)       | 1/2   |    $10.00 |
+| BioPerl.org renewal                         | 1/2   |    $10.00 |
+| Biocpp.{org,net,com} renewal                | 3/9   |    $34.51 |
+| Biosoap.org transfer (incurred 10/2/2013    | 3/17  |    $10.00 |
+|---------------------------------------------|-------|-----------|
+| SPI 5% fees                                 |       |   $ 49.94 |
+
+The actual renewal cost for Biosoap.org was $10.48, but the
+reimbursement request erroneously only asked for $10.00. The
+difference of $0.48 is considered forfeited by the reimbursed Board
+member (Lapp).
+
+Totals for FY 2014:
++ Total programmatic expenses paid:            $2,289.16
++ Total expenses:                              $2,339.10
+
+## Encumbrances
+
+Encumbrances are unpaid liabilities and other financial commitments already incurred, but not yet paid. This includes expenses paid by, but not yet reimbursed to Board members and other persons authorized to make payments on behalf of the OBF.
+
+| Item                           |     Date(s)       |   Amount  |
+|:-------------------------------|:-----------------:|----------:|
+| Biosql.org renewal             | 4/13              |    $10.00 |
+| Biosql.org reinstatement fee   | 4/13              |    $25.99 |
+| Open-bio.org renewal           | 8/16              |    $10.00 |
+| Biopython.org renewal          | 8/16              |    $10.00 |
+| Biosoap.org renewal            | 10/8              |    $11.48 |
+| BioR.org renewal               | 10/18             |    $10.00 |
+| BioPerl.org renewal            | 11/28             |    $10.00 |
+| Amazon Hosting                 | Dec 2013-Nov 2014 | $2,074.47 |
+| GSoC Mentor Summit Travel      | 7/18              |   $821.00 |
+
+Total encumbrances: $2,982.94
+
+## BOSC 2014
+
+| Item                    | Amount         |
+|:------------------------|---------------:|
+| **Starting Balance**    | **$20,915.53** |
+| BOSC Profit share       |   $ 3,311.99   |
+| Programmatic Activities | _($11,610.27)_ |
+| **Ending Balance**      | **$12,617.25** |
+|-------------------------|----------------|
+| BOSC Income             |   $26,160.00   |
+| BOSC Expenses           | _($19,536.03)_ |
+| **BOSC Surplus**        | **$ 6,623.97** |
+
+_Programmatic Activities_ are BOSC/OBF-sponsored activities that go beyond operational activities and logistics already managed and thus covered by ISMB, and includes travel awards, comp'ed registrations, and speaker support. For BOSC 2014, these include the following:
+
+- 12 comp'ed registrations:       $1,600.00
+- Keynote speaker reimbursements: $  809.54
+- Committee chair travel:         $1,581.11
+- Student travel awards:          $1,480.61
+- Videos for talks:               $4,000.00
+- Codefest expenses:              $2,092.01
+- Misc. fees (wire etc):          $   47.00
+
+[SPI]: http://spi-inc.org


### PR DESCRIPTION
SPI and BOSC Escrow combined financial report for OBF's FY 2014 (Dec 2013 - Nov 2014).

This is based on a careful recapitulation of reimbursement requests, SPI Treasurer's Reports, and the BOSC 2014 Escrow statement from Nov 2014. The starting and ending balances match up with the corresponding SPI Treasurer's Reports from Nov/Dec 2013 and Nov 2014, and the BOSC Escrow Statement.