### PR TITLE
clarify travel award criteria

### DIFF
--- a/Travel_fellowships.md
+++ b/Travel_fellowships.md
@@ -9,7 +9,7 @@ judge each criterion.
 
 **Does the event qualify?** Does the event promote open source bioinformatics software
 development and open science in the biological research community? Events can include - but are not limited to - conferences, workshops, codefests, and hackathons. We give
-slight preference to OBF events and member projects. The event can occurs anytime between the previous deadline and the subsequent deadline - i.e. you can apply for something you are planning
+slight preference to OBF events and member projects. The event can occur anytime between the previous deadline and the subsequent deadline - i.e. you can apply for something you are planning
 to attend or have already attended.
 
 **What is your participation?** We look at both your role at the event, your past participation in the project that you are representing, and also your general history in open source development or open science. We give slight preference to

--- a/Travel_fellowships.md
+++ b/Travel_fellowships.md
@@ -1,23 +1,32 @@
 # Open Bioinformatics Foundation Travel Fellowships
 
-The Open Bioinformatics Foundation ([OBF](https://www.open-bio.org)) is pleased to announce a new OBF Travel Fellowship program aimed at increasing diverse participation at events promoting open source bioinformatics software development and open science in the biological research community. 
+The Open Bioinformatics Foundation ([OBF](https://www.open-bio.org)) is pleased to announce a new OBF Travel Fellowship program aimed at increasing diverse participation at events promoting open source bioinformatics software development and open science in the biological research community.
 
-## Who can apply?
-Anyone participating in open source software development or developing / promoting other aspects of open science in biology. Applicants should be able to document their public activity in the project(s) being discussed / developed at the event. Projects need not be OBF member projects. Preference will be given to applicants who increase diversity at the event they intend to attend. We understand increasing diversity as increasing participation from groups otherwise underrepresented in the community or at the event, including but not limited to underrepresented demographic groups, ethnic origins, career stages, and people with disabilities.
+## What is the selection criteria?
+We get more applications that we can fund in each round. Selection is based on
+the following criteria. Make sure that you include sufficient information on the application form for us to
+judge each criterion.
 
-## Which events qualify?
-Any event that aims to develop or promote open source development and open science in the biological research community. This includes - but is not limited to - conferences, workshops, codefests, and hackathons. 
+**Does the event qualify?** Does the event promote open source bioinformatics software
+development and open science in the biological research community? Events can include - but are not limited to - conferences, workshops, codefests, and hackathons. We give
+slight preference to events for OBF member projects. The event can occurs anytime between the previous deadline and the subsequent deadline - i.e. you can apply for something you are planning
+to attend or have already attended.
+
+**What is your participation?** We look at both your role at the event, your past participation in the project that you are representing, and also your general history in open source development or open science. We give slight preference to
+participation in OBF member projects.
+
+**Increasing diversity**: Does your attendance increase diversity at the event? We understand increasing diversity as increasing participation from groups otherwise underrepresented in the community or at the event, including but not limited to underrepresented demographic groups, ethnic origins, career stages, and people with disabilities. We do not consider diversity of operating systems or text editors.
 
 ## What does the fellowship cover?
-The fellowship can be used to cover airfare, hotel and / or conference registration fees up to a value of USD 1,000. We anticipate that these awards will supplement travel costs, not cover all expenses. If you anticipate that you would require more than USD 1,000 in order to attend the event, please include that information on the application form. The OBF will reimburse the recipient after the event based on receipts provided and proof of attendance. There is no cash value beyond eligible and documented expenses. 
+The fellowship can be used to cover airfare, hotel and / or conference registration fees up to a value of USD 1,000. We anticipate that these awards will supplement travel costs, not cover all expenses. If you anticipate that you would require more than USD 1,000 in order to attend the event, please include that information on the application form. The OBF will reimburse the recipient after the event based on receipts provided and proof of attendance. There is no cash value beyond eligible and documented expenses.
 
 ## What do you require of applicants?
-We expect that your participation in the event will promote open source software development and / or open science in the biological research community, and will ideally promote diversity in this community. After the event, we require that applicants write a blog post that we will reference or post on the [OBF blog](https://news.open-bio.org/).
+We expect that your participation in the event will promote open source software development and / or open science in the biological research community, and will ideally promote diversity in this community. Before reimbursement, we require that applicants write a blog post about the event that we will reference or post on the [OBF blog](https://news.open-bio.org/).
 
 ## Who will review the applications?
-The applications will be considered by the OBF Board of Directors. Individual directors with a clear conflict of interest will recuse themselves.
+The review panel is drawn from the OBF Board of Directors and OBF members. Any panelist with a clear conflict of interest will recuse themselves from deliberation.
 
 ## How to apply
-Fill out [the application form](https://goo.gl/forms/dtXho2780SFQOCWt2). Applicants will be notified of the outcome no later than 3 weeks after the application deadline. 
+Fill out [the application form](https://goo.gl/forms/dtXho2780SFQOCWt2). Applicants will be notified of the outcome no later than 3 weeks after the application deadline.
 
 **Application Deadlines**: April 15, August 15, December 15

--- a/Travel_fellowships.md
+++ b/Travel_fellowships.md
@@ -9,11 +9,11 @@ judge each criterion.
 
 **Does the event qualify?** Does the event promote open source bioinformatics software
 development and open science in the biological research community? Events can include - but are not limited to - conferences, workshops, codefests, and hackathons. We give
-slight preference to events for OBF member projects. The event can occurs anytime between the previous deadline and the subsequent deadline - i.e. you can apply for something you are planning
+slight preference to OBF events and member projects. The event can occurs anytime between the previous deadline and the subsequent deadline - i.e. you can apply for something you are planning
 to attend or have already attended.
 
 **What is your participation?** We look at both your role at the event, your past participation in the project that you are representing, and also your general history in open source development or open science. We give slight preference to
-participation in OBF member projects.
+participation in OBF events and member projects.
 
 **Increasing diversity**: Does your attendance increase diversity at the event? We understand increasing diversity as increasing participation from groups otherwise underrepresented in the community or at the event, including but not limited to underrepresented demographic groups, ethnic origins, career stages, and people with disabilities. We do not consider diversity of operating systems or text editors.
 


### PR DESCRIPTION
I've merged the information about 'who can apply' and 'what events qualify' into a new section that describes review criteria. Includes 1) being explicit about past and future events; 2) slight preference for OBF projects / events; 3) blog post required for reimbursement. 

Let me know what you think. @hlapp @HLWiencko @peterjc @cjfields @nlharris 