### PR TITLE
Allows for other projects to be grandfathered

### DIFF
--- a/Affiliated-Project-Policy.md
+++ b/Affiliated-Project-Policy.md
@@ -137,6 +137,8 @@ The status of Affiliated and Candidate OBF Projects that are not voted on stays 
 
 The projects considered OBF member projects prior to enactment of this policy are grandfathered to Affiliated OBF Project status. These projects are the so-called Bio\* Projects, which consist of [BioPerl], [Biopython], [BioJava], [BioRuby], [BioSQL]; [DAS] (Distributed Annotation System); and [EMBOSS] (European Molecular Biology Open Software Suite).
 
+Other projects that existed prior to enactment of this policy can be grandfathered to Affiliated or Candidate OBF Project status as well upon approval by the OBF Board of Directors. It is expected that the Board will do so in public session. For pre-existing projects grandfathered to Candidate OBF Project status the minimum waiting period for seeking Affiliate OBF Project status is waived.
+
 ## Dispute and Board Veto
 
 Any dispute on votes or current affiliation status of a project must


### PR DESCRIPTION
We have been approached in the past by a number of different projects about how to become an OBF member. That there wasn't a policy when they asked wasn't their fault, and hence arguably there should be some kind of fast-track path for those. This change gives the Board broad powers to grandfather pre-existing projects, but the most typical use of this will be in essence "fast-track" projects that wanted to become members in the past, by grandfathering them into Candidate OBF Project status instead of them having to wait for the next community vote to attain it, and then having to wait another year before they are eligible for a vote on Affiliated status.