### PR TITLE
Approval of minutes for July 2019 Public Board Meeting

### DIFF
--- a/minutes/2019-July.md
+++ b/minutes/2019-July.md
@@ -1,5 +1,3 @@
-_These minutes are in draft status and have not yet formally approved._
-
 ## 2019-July Public Board Meeting
 
 **Present**: Hilmar, Nomi, Heather, Yo, Peter, Chris (remote), Bastian


### PR DESCRIPTION
Because these weren't initially put on a pending pull request, this creates a pull request for formal Board approval at the next public Board meeting.