### PR TITLE
Adds date and location to July 2019 Public Board Meeting minutes

### DIFF
--- a/minutes/2019-July.md
+++ b/minutes/2019-July.md
@@ -4,7 +4,7 @@
 
 *Guests*: Malvika Sharan, Daniel Davies (remote), Michael Heuer, Spencer Bliven, Raony Guimaraes, Michael Crusoe, Matúš Kalaš
 
-*Date and Location*: July 25, 12:45pm CEST, Congress Center Basel, Switzerland, in the Dehli Room
+*Date and Location*: July 25, 2019, 12:45pm CEST, Congress Center Basel, Switzerland, in the Delhi Room
 
 *Agenda*: [https://www.open-bio.org/2019/07/23/minutes2019-bosc/](https://www.open-bio.org/2019/07/23/minutes2019-bosc/)
 

--- a/minutes/2019-July.md
+++ b/minutes/2019-July.md
@@ -1,12 +1,16 @@
-## 2019-July Public Board Meeting
+# 2019-July Public Board Meeting
 
 **Present**: Hilmar, Nomi, Heather, Yo, Peter, Chris (remote), Bastian
 
 *Guests*: Malvika Sharan, Daniel Davies (remote), Michael Heuer, Spencer Bliven, Raony Guimaraes, Michael Crusoe, Matúš Kalaš
 
+*Date and Location*: July 25, 12:45pm CEST, Congress Center Basel, Switzerland, in the Dehli Room
+
 *Agenda*: [https://www.open-bio.org/2019/07/23/minutes2019-bosc/](https://www.open-bio.org/2019/07/23/minutes2019-bosc/)
 
-*Minutes*:  12:49pm CEST: Meeting is called to order by Hilmar.
+## Minutes
+
+12:49pm CEST: Meeting is called to order by Hilmar.
 
 ### Approval of 2018 Minutes:
 


### PR DESCRIPTION
Somehow this was omitted and not caught prior to approval. However, adding it doesn't alter the minutes, so shouldn't require renewed Public Board meeting approval.

Also makes "Minutes" into what it is, a heading.