### PR TITLE
Explicitly include poster printing as an eligible expense

### DIFF
--- a/Travel_fellowships.md
+++ b/Travel_fellowships.md
@@ -71,7 +71,7 @@ The OBF Event Fellowships are available for the awardees to cover conference reg
 
 ### Items covered for in-person participation
 
-The fellowship can be used to cover conference registration fees and direct travel costs (such as airfare, train, metro, bus and taxi), hotel, and/or child-care up to a value of USD 1,000. 
+The fellowship can be used to cover conference registration fees and direct travel costs (such as airfare, train, metro, bus and taxi), hotel, poster printing (if presenting a poster at the conference), and/or child-care up to a value of USD 1,000. 
 Note that rental car expenses and personal car mileage are not eligible for reimbursement. 
 If the applicants anticipate that they would require more than USD 1,000 in order to attend the event, they should include that information in the application form.
 Please note that requests made for more than $1000 may not be granted if not clearly justified by the applicants.


### PR DESCRIPTION
As per the title, poster printing costs seem a reasonable conference expense to cover (either in the home country, or on site to avoid travelling with awkward luggage).