### PR TITLE
Disclaimer about non-attendance

### DIFF
--- a/Travel_fellowships.md
+++ b/Travel_fellowships.md
@@ -76,6 +76,7 @@ Note that rental car expenses and personal car mileage are not eligible for reim
 Lodging for earlier than the night before the first day of the event, or beyond the night the event ends, requires justification and is subject to Board approval.
 If the applicants anticipate that they would require more than USD 1,000 in order to attend the event, they should include that information in the application form.
 Please note that requests made for more than $1000 may not be granted if not clearly justified by the applicants.
+If the candidate does not attend the sponsored event, funds may not be reimbursed, at the discretion of the committee.
 
 ### Items covered for remote participation
 


### PR DESCRIPTION
Wording suggested by another board member:

> If the candidate does not attend the sponsored event, funds may not be reimbursed, at the discretion of the committee.

Could be at the discretion of the board?