### PR TITLE
Add 2021-Sept meeting minutes

### DIFF
--- a/minutes/2021-Sept.md
+++ b/minutes/2021-Sept.md
@@ -1,0 +1,65 @@
+**Present:** Peter Cock, Chris Fields, Heather Wiencko, Nomi Harris, Bastian Greshake-Tzovaras, Hilmar Lapp
+**Apologies:** Malvika Sharan (board member), Hilyatuz Zahroh (board candidate)
+
+**Also attending:** Caleb Kibet (board candidate), Yo Yehudi, Pablo Riesgo Ferreiro
+
+
+**Agenda:**
+Please see the [Blog Post for agenda points](https://www.open-bio.org/2021/09/11/obf-public-board-meeting-2021-09-21/)
+
+*Minutes:* Meeting called to order by Peter Cock at 17:02 UTC
+
+## Old Business
+
+* Approve minutes from the previous Public Board Meeting: https://github.com/OBF/obf-docs/pull/87 
+	* Peter proposes approving minutes, Chris seconds.  Motion carried by unanimous consent.
+	* Minutes are now in the repository
+
+## Board elections
+
+Term expirations and Elections to the Board (electronic ballot)
+
+* Hilyatuz Zahroh and Caleb Kibet, running for Board member at-large
+	* Candidate videos from Hilya and Caleb made available for the Board and public
+	* Hilya was unable to join due to time zone differences
+* Board member Bastian Greshake Tzovaras’ term expires this year and he would like to stand for another term as member-at-large.
+* [Vote is finalized via Helios](https://vote.heliosvoting.org/helios/e/obf-board-2021) 
+	* Re-elect Bastian - 5 in favor, 1 abstain
+	* Hilya - 6 in favor
+	* Caleb - 6 in favor
+* Onboarding:
+    * Peter: Need to add Hilya and Caleb to Board resources 
+    * Chris will coordinate this
+
+## Motions
+
+* Board would like to recognize and acknowledge Yo Yehudi on her past work as a Board member, on the Google Summer of Code, BOSC organization, CoC, affiliate project membership, and initiating the OBF news letter
+	* Hilmar Lapp initiated motion, Peter seconded, with unanimous consent from the Board
+
+## Announcement of voting among OBF membership:
+
+Proposed wording for two items that membership will vote on
+
+First:
+
+> *Community Support Sponsorship*
+>
+> The OBF is proposing a Community Support Sponsorship grant programme, giving funds to grassroots communities in return for our logo appearing on their event webpages and materials, acknowledging our support. Please use https://github.com/OBF/obf-docs/issues/86 for specific comments. 
+> * https://www.open-bio.org/2021/05/11/obf-community-support-sponsorship/
+> * https://github.com/OBF/obf-docs/issues/86 
+> Do you support the board implementing this scheme? (Yes/No/Abstain)
+
+Second:
+
+> *OBF Code of Conduct*
+>
+>The OBF would like to adopt a code of conduct (COC) for its activities including meetings and member projects. See pull request https://github.com/OBF/obf-docs/pull/78 for the proposal. 
+> Do you support adopting this COC? (Yes/No/Abstain)
+
+* Peter - end of month deadline for both (check notes and recording)
+* Peter - Motion that the votes on the above motions is binding.  
+    * Hilmar seconded with no objections; motion carried with unanimous consent
+
+## Adjournment
+
+* Peter: motion to close the public board meeting; Hilmar seconded.  No objections, motion carried with unanimous consent.  Meeting adjourned at 17:30 UTC 


### PR DESCRIPTION
Reverts OBF/obf-docs#103, which will in effect add back the minutes *once approved in the next public board meeting*.  